### PR TITLE
feat(slurm): give each rule its own named resource block

### DIFF
--- a/docs/source/user_guide/configuration.md
+++ b/docs/source/user_guide/configuration.md
@@ -71,10 +71,17 @@ suite2p_ops:
 # SLURM settings (one block per rule, named after the rule)
 use_slurm: false
 slurm:
+  _common: &common
+    tasks: 1
+    nodes: 1
+
   preprocessing:
+    <<: *common
     slurm_partition: "cpu"
     mem_mb: 8000
+
   suite2p:
+    <<: *common
     slurm_partition: "gpu"
     mem_mb: 32000
 ```
@@ -129,29 +136,9 @@ In order for SLURM jobs to be executed, you have to launch `photon-mosaic-pipeli
 
 #### Resources are set per rule
 
-The `slurm:` block holds **one sub-block per rule, named after the rule**. Each rule uses only its own block:
+The `slurm:` block holds **one sub-block per rule, named after the rule**, and a rule uses only its own block. Rules have genuinely different needs — `suite2p` wants a GPU, preprocessing is CPU-only — and one shared block means the CPU step requests a GPU it never uses and then waits in the GPU queue for it.
 
-```yaml
-slurm:
-  preprocessing:
-    slurm_partition: "cpu"
-    mem_mb: 8000
-
-  suite2p:
-    slurm_partition: "gpu"
-    gres: "gpu:a4500:1"
-    mem_mb: 32000
-```
-
-Rules have genuinely different needs — `suite2p` wants a GPU, preprocessing is CPU-only — and giving every rule the same resources means the CPU step requests a GPU it never uses and then waits in the GPU queue for it. With its own block, preprocessing goes straight to the CPU partition.
-
-Nothing is inherited between blocks, so a rule never has to *remove* a resource it did not want.
-
-**Every rule needs a block.** A rule with no block of its own requests nothing but its log paths, and will be submitted with whatever your cluster defaults to. If you add a rule, add its block.
-
-#### Sharing keys between rules
-
-For keys that really are the same everywhere, use a YAML anchor rather than repeating them. Define them once under a key starting with `_` (keys starting with `_` are treated as config scaffolding and are never passed to SLURM), then pull them in with `<<:`:
+Keys that really are the same everywhere go in a YAML anchor rather than being repeated. Keys starting with `_` are config scaffolding and are never passed to SLURM, which makes `_common` a safe place to hold one:
 
 ```yaml
 slurm:
@@ -172,19 +159,13 @@ slurm:
     mem_mb: 32000
 ```
 
-A key set in a rule's own block wins over the anchor, so `mem_mb` above differs per rule while `runtime` is shared.
+A key set in a rule's own block wins over the anchor, so `mem_mb` differs per rule while `runtime` is shared. Nothing else is inherited, so a rule never has to *remove* a resource it did not want. `slurm_account` is cluster-specific: replace the placeholder with your own account, or delete the line if your cluster does not require one.
 
-`slurm_account` is specific to your cluster — the shipped config leaves it commented out with a placeholder. Replace `your_account_name` with your own account, or delete the line if your cluster does not require one.
-
-#### Older, flat configs
-
-A `slurm:` block with no per-rule sub-blocks still applies to every rule, so existing configs keep working and per-rule blocks are opt-in. Two small differences from before: `null` values and any nested blocks are no longer passed to SLURM as resources.
-
-You can also migrate one rule at a time — give a rule its own block and leave the rest on the flat keys. A rule with its own block uses **only** that block; it does not pick up the flat keys as well.
+**Every rule needs a block.** A rule with no block of its own requests nothing but its log paths, and is submitted with whatever your cluster defaults to. If you add a rule, add its block. (A `slurm:` block with *no* per-rule sub-blocks at all still applies to every rule, so older flat configs keep working — except that `null` values and nested blocks are no longer forwarded as resources.)
 
 #### GPU resources: `gpu` vs `gres`
 
-The Snakemake SLURM executor plugin offers **two mutually exclusive ways** to request a GPU. You have to pick one! Combining them produces TRES (Trackable RESources) conflicts at the scheduler. Put them in the block of the rule that needs the GPU — usually `suite2p` — so that no other rule requests one.
+The Snakemake SLURM executor plugin offers **two mutually exclusive ways** to request a GPU, because `--gpus` and `--gres` describe the same TRES (Trackable RESource) two different ways, and asking for both is ambiguous. You have to pick one! Set both and Snakemake refuses to build the submission at all, with `GRES and GPU are set. Please only set one of them.` Put the key in the block of the rule that needs the GPU — usually `suite2p` — so that no other rule requests one.
 
 - **`gpu`**: request a number of GPUs of any type. The plugin translates this into `--gpus`. Pair with `cpus_per_gpu` if needed.
 

--- a/docs/source/user_guide/configuration.md
+++ b/docs/source/user_guide/configuration.md
@@ -119,10 +119,11 @@ Photon-mosaic uses Cellpose 4 by default, with `cpsam` model. If you want to use
 
 ### SLURM
 - `use_slurm`: Enable/disable SLURM job scheduling (default: false)
-- `slurm_partition`: Compute partition to use
-- `mem_mb`: Memory allocation per job
-- `tasks`: Number of parallel tasks
-- `nodes`: Number of compute nodes
+- `slurm`: One sub-block per rule (see below), each holding that rule's resources:
+  - `slurm_partition`: Compute partition to use
+  - `mem_mb`: Memory allocation per job
+  - `tasks`: Number of parallel tasks
+  - `nodes`: Number of compute nodes
 
 In order for SLURM jobs to be executed, you have to launch `photon-mosaic-pipeline` inside an environment in an interactive job in your cluster.
 
@@ -146,7 +147,7 @@ Rules have genuinely different needs — `suite2p` wants a GPU, preprocessing is
 
 Nothing is inherited between blocks, so a rule never has to *remove* a resource it did not want.
 
-**Every rule needs a block.** A rule with no block gets no resources at all and will be submitted with whatever your cluster defaults to. If you add a rule, add its block.
+**Every rule needs a block.** A rule with no block of its own requests nothing but its log paths, and will be submitted with whatever your cluster defaults to. If you add a rule, add its block.
 
 #### Sharing keys between rules
 
@@ -177,34 +178,30 @@ A key set in a rule's own block wins over the anchor, so `mem_mb` above differs 
 
 #### Older, flat configs
 
-A `slurm:` block with no per-rule sub-blocks still works and applies to every rule, exactly as before. Existing configs keep running unchanged; per-rule blocks are opt-in.
+A `slurm:` block with no per-rule sub-blocks still applies to every rule, so existing configs keep working and per-rule blocks are opt-in. Two small differences from before: `null` values and any nested blocks are no longer passed to SLURM as resources.
+
+You can also migrate one rule at a time — give a rule its own block and leave the rest on the flat keys. A rule with its own block uses **only** that block; it does not pick up the flat keys as well.
 
 #### GPU resources: `gpu` vs `gres`
 
-The Snakemake SLURM executor plugin offers **two mutually exclusive ways** to request a GPU. You have to pick one! Combining them produces TRES (Trackable RESources) conflicts at the scheduler.
+The Snakemake SLURM executor plugin offers **two mutually exclusive ways** to request a GPU. You have to pick one! Combining them produces TRES (Trackable RESources) conflicts at the scheduler. Put them in the block of the rule that needs the GPU — usually `suite2p` — so that no other rule requests one.
 
 - **`gpu`**: request a number of GPUs of any type. The plugin translates this into `--gpus`. Pair with `cpus_per_gpu` if needed.
 
   ```yaml
   slurm:
-    gpu: 1
-    cpus_per_gpu: 4
+    suite2p:
+      gpu: 1
+      cpus_per_gpu: 4
   ```
 
 - **`gres`**: request a specific GPU model via SLURM's Generic Resource string. The plugin translates this into `--gres`. Use this when the cluster has mixed GPU types and you need a specific one (e.g. `"gpu:a100:1"` for one A100). Do **not** also set `gpu`.
 
   ```yaml
   slurm:
-    gres: "gpu:a100:1"
+    suite2p:
+      gres: "gpu:a100:1"
   ```
-
-These keys live under `slurm:` but are forwarded to the rule level, not to Snakemake's `--default-resources`. On startup you will see an `INFO` log line such as:
-
-```
-INFO:photon_mosaic_pipeline.cli:Skipping gres in --default-resources (set at rule level to avoid conflicts): gpu:a100:1
-```
-
-That is expected behaviour, not an error: it confirms the value was picked up and routed to per-rule resources to avoid TRES conflicts. The same applies to `gpu` and `cpus_per_gpu`.
 
 For the upstream mechanics, see the [GRES alternative method](https://snakemake.github.io/snakemake-plugin-catalog/plugins/executor/slurm.html#alternative-method-using-the-gres-resource) in the Snakemake SLURM plugin docs.
 

--- a/docs/source/user_guide/configuration.md
+++ b/docs/source/user_guide/configuration.md
@@ -68,13 +68,15 @@ suite2p_ops:
   roidetect: true
   anatomical_only: 0
 
-# SLURM settings
+# SLURM settings (one block per rule, named after the rule)
 use_slurm: false
 slurm:
-  slurm_partition: "gpu"
-  mem_mb: 32000
-  tasks: 1
-  nodes: 1
+  preprocessing:
+    slurm_partition: "cpu"
+    mem_mb: 8000
+  suite2p:
+    slurm_partition: "gpu"
+    mem_mb: 32000
 ```
 
 For the complete configuration file with all available parameters and detailed comments, see [photon_mosaic_pipeline/workflow/config.yaml](https://github.com/photon-mosaic/photon-mosaic-pipeline/blob/main/photon_mosaic_pipeline/workflow/config.yaml) or the YAML file in `~/.photon_mosaic_pipeline/config.yaml` generated on first run.
@@ -123,6 +125,59 @@ Photon-mosaic uses Cellpose 4 by default, with `cpsam` model. If you want to use
 - `nodes`: Number of compute nodes
 
 In order for SLURM jobs to be executed, you have to launch `photon-mosaic-pipeline` inside an environment in an interactive job in your cluster.
+
+#### Resources are set per rule
+
+The `slurm:` block holds **one sub-block per rule, named after the rule**. Each rule uses only its own block:
+
+```yaml
+slurm:
+  preprocessing:
+    slurm_partition: "cpu"
+    mem_mb: 8000
+
+  suite2p:
+    slurm_partition: "gpu"
+    gres: "gpu:a4500:1"
+    mem_mb: 32000
+```
+
+Rules have genuinely different needs — `suite2p` wants a GPU, preprocessing is CPU-only — and giving every rule the same resources means the CPU step requests a GPU it never uses and then waits in the GPU queue for it. With its own block, preprocessing goes straight to the CPU partition.
+
+Nothing is inherited between blocks, so a rule never has to *remove* a resource it did not want.
+
+**Every rule needs a block.** A rule with no block gets no resources at all and will be submitted with whatever your cluster defaults to. If you add a rule, add its block.
+
+#### Sharing keys between rules
+
+For keys that really are the same everywhere, use a YAML anchor rather than repeating them. Define them once under a key starting with `_` (keys starting with `_` are treated as config scaffolding and are never passed to SLURM), then pull them in with `<<:`:
+
+```yaml
+slurm:
+  _common: &common
+    tasks: 1
+    nodes: 1
+    runtime: 120
+    # slurm_account: "your_account_name"   # replace with YOUR cluster account
+
+  preprocessing:
+    <<: *common
+    slurm_partition: "cpu"
+    mem_mb: 8000
+
+  suite2p:
+    <<: *common
+    slurm_partition: "gpu"
+    mem_mb: 32000
+```
+
+A key set in a rule's own block wins over the anchor, so `mem_mb` above differs per rule while `runtime` is shared.
+
+`slurm_account` is specific to your cluster — the shipped config leaves it commented out with a placeholder. Replace `your_account_name` with your own account, or delete the line if your cluster does not require one.
+
+#### Older, flat configs
+
+A `slurm:` block with no per-rule sub-blocks still works and applies to every rule, exactly as before. Existing configs keep running unchanged; per-rule blocks are opt-in.
 
 #### GPU resources: `gpu` vs `gres`
 

--- a/docs/source/user_guide/configuration.md
+++ b/docs/source/user_guide/configuration.md
@@ -136,9 +136,11 @@ In order for SLURM jobs to be executed, you have to launch `photon-mosaic-pipeli
 
 #### Resources are set per rule
 
-The `slurm:` block holds **one sub-block per rule, named after the rule**, and a rule uses only its own block. Rules have genuinely different needs — `suite2p` wants a GPU, preprocessing is CPU-only — and one shared block means the CPU step requests a GPU it never uses and then waits in the GPU queue for it.
+Each step of the pipeline — each Snakemake *rule* — is sent to SLURM as its own job, and every job has to say what hardware it needs: which partition, how much memory, and so on. Different steps need different things: `suite2p` needs a GPU, preprocessing does not.
 
-Keys that really are the same everywhere go in a YAML anchor rather than being repeated. Keys starting with `_` are config scaffolding and are never passed to SLURM, which makes `_common` a safe place to hold one:
+So `slurm:` holds **one block per rule, named after the rule**, and a rule reads only its own block. If both steps shared one set of resources, preprocessing would ask for a GPU as well — and a job that asks for a GPU waits in the queue for one, so a step that never touches the GPU would sit waiting for it anyway.
+
+Repeating the settings that genuinely are the same in every block gets tedious, so write them once and reuse them. YAML does this on its own, with an anchor (`&common`) and a merge (`<<: *common`). Any key starting with `_` is ignored when the resources are read, which makes `_common` a safe place to keep the shared ones:
 
 ```yaml
 slurm:
@@ -159,9 +161,9 @@ slurm:
     mem_mb: 32000
 ```
 
-A key set in a rule's own block wins over the anchor, so `mem_mb` differs per rule while `runtime` is shared. Nothing else is inherited, so a rule never has to *remove* a resource it did not want. `slurm_account` is cluster-specific: replace the placeholder with your own account, or delete the line if your cluster does not require one.
+A rule's own keys win over the shared ones: above, `runtime` is the same everywhere while `mem_mb` differs. Apart from the anchor nothing is inherited — a rule gets exactly what its own block lists — so you never have to switch off something another rule asked for. `slurm_account` is specific to your cluster: replace the placeholder with your own account, or delete the line if your cluster does not need one.
 
-**Every rule needs a block.** A rule with no block of its own requests nothing but its log paths, and is submitted with whatever your cluster defaults to. If you add a rule, add its block. (A `slurm:` block with *no* per-rule sub-blocks at all still applies to every rule, so older flat configs keep working — except that `null` values and nested blocks are no longer forwarded as resources.)
+**Every rule needs a block.** A rule with no block of its own asks for nothing except its log paths, and is submitted with whatever your cluster gives it by default. If you add a rule, add its block. (A `slurm:` block written the old way, with no per-rule blocks inside it at all, still applies to every rule, so existing configs keep working — except that `null` values and nested blocks are no longer passed on as resources.)
 
 #### GPU resources: `gpu` vs `gres`
 

--- a/photon_mosaic_pipeline/cli.py
+++ b/photon_mosaic_pipeline/cli.py
@@ -309,6 +309,70 @@ def build_snakemake_command(args, config_path):
     return cmd
 
 
+def slurm_log_directory(config):
+    """Return (and create) the directory SLURM job logs are written to.
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary
+
+    Returns
+    -------
+    Path
+        The SLURM log directory.
+    """
+    slurm_logdir = (
+        Path(config["project_path"]).resolve()
+        / "derivatives"
+        / "photon-mosaic-pipeline"
+        / "logs"
+        / "slurm"
+    )
+    ensure_dir(slurm_logdir, mode=0o755, parents=True, exist_ok=True)
+    return slurm_logdir
+
+
+def inject_slurm_log_paths(config):
+    """Point each rule's ``slurm_extra`` at the SLURM log directory.
+
+    ``slurm_extra`` carries the sbatch ``--output``/``--error`` paths. Rules
+    read their resources from the *written* config file, so this has to happen
+    before the timestamped config is saved -- and it has to reach every rule's
+    block, since there are no default resources to fall back on.
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary. Modified in place.
+    """
+    logger = logging.getLogger(__name__)
+
+    if not config.get("use_slurm", False):
+        return
+
+    slurm_logdir = slurm_log_directory(config)
+
+    # %j = SLURM job ID, %x = job name (rule name)
+    slurm_extra = (
+        f"--output={slurm_logdir}/%j_%x.out "
+        f"--error={slurm_logdir}/%j_%x.err"
+    )
+
+    slurm_config = config.setdefault("slurm", {})
+    rule_blocks = [
+        block
+        for key, block in slurm_config.items()
+        if isinstance(block, dict) and not key.startswith("_")
+    ]
+    # A flat slurm: block (no per-rule sub-blocks) applies to every rule, so
+    # the log paths belong on the block itself.
+    for block in rule_blocks or [slurm_config]:
+        block["slurm_extra"] = slurm_extra
+
+    logger.info(f"SLURM logs will be saved to: {slurm_logdir}")
+
+
 def configure_slurm_execution(cmd, config):
     """Configure SLURM execution options if enabled.
 
@@ -336,74 +400,15 @@ def configure_slurm_execution(cmd, config):
     # Keep SLURM logs after successful job completion
     cmd.append("--slurm-keep-successful-logs")
 
-    # Configure SLURM log directory to persist logs
-    project_path = Path(config["project_path"]).resolve()
-    slurm_logdir = (
-        project_path
-        / "derivatives"
-        / "photon-mosaic-pipeline"
-        / "logs"
-        / "slurm"
-    )
-    ensure_dir(slurm_logdir, mode=0o755, parents=True, exist_ok=True)
-
     # Use the dedicated --slurm-logdir flag to configure Snakemake's internal
     # logs
-    cmd.extend(["--slurm-logdir", str(slurm_logdir)])
+    cmd.extend(["--slurm-logdir", str(slurm_log_directory(config))])
 
-    logger.info(f"SLURM logs will be saved to: {slurm_logdir}")
-
-    # Add SLURM-specific arguments
-    slurm_config = config.get("slurm", {}).copy()
-
-    # Override slurm_extra to properly set SLURM stdout/stderr paths
-    # This ensures the actual sbatch output/error files go to the correct
-    # location
-    # %j = SLURM job ID, %x = job name (rule name)
-    slurm_config["slurm_extra"] = (
-        f"--output={slurm_logdir}/%j_%x.out "
-        f"--error={slurm_logdir}/%j_%x.err"
-    )
-
-    logger.info(f"Configuration loaded: {slurm_config}")
-
-    # Resources that should NOT be passed via --default-resources
-    # because they're already set at rule level and may cause conflicts
-    # (particularly gpu-related resources that can trigger TRES conflicts)
-    # Note: tasks_per_gpu is NOT excluded as it's needed
-    # to control --ntasks-per-gpu behavior
-    exclude_from_defaults = {"gpu", "gres", "cpus_per_gpu"}
-
-    # Create default resources string for SLURM by iterating all provided keys
-    default_resources = []
-    for key, value in slurm_config.items():
-        # Skip empty/null values
-        if value is None:
-            continue
-        # Skip resources that should only be set at rule level
-        if key in exclude_from_defaults:
-            logger.info(
-                f"Skipping {key} in --default-resources "
-                f"(set at rule level to avoid conflicts): {value}"
-            )
-            continue
-        # Quote string values so snakemake parses them correctly
-        if isinstance(value, str):
-            default_resources.append(f"{key}='{value}'")
-        # Use lower-case for booleans (true/false)
-        elif isinstance(value, bool):
-            default_resources.append(f"{key}={str(value).lower()}")
-        else:
-            default_resources.append(f"{key}={value}")
-
-        logger.info(f"Using SLURM {key}: {value}")
-
-    if default_resources:
-        # Join all default resources with commas and pass as single argument
-        resources_str = ",".join(default_resources)
-        cmd.extend(["--default-resources", resources_str])
-        logger.info(f"SLURM default resources: {resources_str}")
-
+    # No --default-resources: every rule reads its own block from the config
+    # (see snakemake_utils.slurm_resources), so there is nothing left for the
+    # defaults to supply. Snakemake fills defaults in only for resources a rule
+    # does not set, which would silently reintroduce values a rule left out.
+    logger.info(f"SLURM configuration: {config.get('slurm', {})}")
     logger.info("SLURM executor configured successfully")
     return cmd
 
@@ -540,6 +545,10 @@ def main():
     # Set up output directories
     project_path = Path(config["project_path"])
     output_dir, logs_dir, configs_dir = setup_output_directories(project_path)
+
+    # Point each rule's slurm_extra at the log directory. Must happen BEFORE
+    # the config is saved: the rules read their resources from that file.
+    inject_slurm_log_paths(config)
 
     # Save timestamped config for reproducibility
     timestamp, config_path = save_timestamped_config(config, configs_dir)

--- a/photon_mosaic_pipeline/cli.py
+++ b/photon_mosaic_pipeline/cli.py
@@ -365,9 +365,13 @@ def inject_slurm_log_paths(config):
         for key, block in slurm_config.items()
         if isinstance(block, dict) and not key.startswith("_")
     ]
-    # A flat slurm: block (no per-rule sub-blocks) applies to every rule, so
-    # the log paths belong on the block itself.
-    for block in rule_blocks or [slurm_config]:
+    # Every rule block, AND the flat keys. A config may be mixed -- some rules
+    # given their own block, the rest still falling back to the flat keys --
+    # which is the natural way to migrate one rule at a time. Injecting only
+    # into the sub-blocks would leave those un-blocked rules with resources but
+    # no --output/--error, so their sbatch logs would silently land in the
+    # working directory.
+    for block in [*rule_blocks, slurm_config]:
         block["slurm_extra"] = slurm_extra
 
     logger.info(f"SLURM logs will be saved to: {slurm_logdir}")

--- a/photon_mosaic_pipeline/snakemake_utils.py
+++ b/photon_mosaic_pipeline/snakemake_utils.py
@@ -45,6 +45,61 @@ def cross_platform_path(path):
         return str(path)
 
 
+def slurm_resources(config, rule_name):
+    """Return the SLURM resources for one rule.
+
+    The ``slurm`` config block holds one sub-block per rule, named after the
+    rule (``slurm.preprocessing``, ``slurm.suite2p``). Each rule reads its own
+    block and nothing else -- there is no inheritance, so a rule never has to
+    remove a resource it did not want. Keys shared between rules are best
+    expressed with a YAML anchor in the config itself::
+
+        slurm:
+          _common: &common
+            runtime: 120
+          preprocessing:
+            <<: *common
+            slurm_partition: "cpu"
+
+    A ``slurm`` block with no per-rule sub-blocks is treated as applying to
+    every rule, which is how it behaved before per-rule blocks existed.
+
+    Parameters
+    ----------
+    config : dict
+        The full workflow config.
+    rule_name : str
+        Name of the rule to resolve resources for.
+
+    Returns
+    -------
+    dict
+        Flat ``{resource: value}`` mapping, empty when SLURM is disabled.
+    """
+    if not config.get("use_slurm"):
+        return {}
+
+    slurm_config = config.get("slurm") or {}
+    block = slurm_config.get(rule_name)
+
+    if block is None:
+        # Backwards compatibility: a flat slurm: block (no per-rule
+        # sub-blocks) applies to every rule, as it did before.
+        block = {
+            key: value
+            for key, value in slurm_config.items()
+            if not isinstance(value, dict)
+        }
+
+    # Drop nulls (not a resource) and the underscore-prefixed keys used to
+    # hold YAML anchors, which are config scaffolding rather than resources.
+    return {
+        key: value
+        for key, value in block.items()
+        if value is not None and not key.startswith("_")
+    }
+
+
 def log_cuda_availability():
     """Log CUDA availability as a sanity check for GPU jobs.
 

--- a/photon_mosaic_pipeline/workflow/config.yaml
+++ b/photon_mosaic_pipeline/workflow/config.yaml
@@ -202,5 +202,4 @@ slurm:
     # gpu: 1                 # Number of GPUs to request
     # gres: "gpu:a100:1"     # Alternative: Generic Resource (GRES) specification
     # cpus_per_gpu: 4        # CPUs allocated per GPU
-    # tasks_per_gpu: 0       # Tasks per GPU (set to 0 to disable --ntasks-per-gpu and avoid TRES conflicts)
     # mem_mb_per_cpu: 2000   # Memory per CPU (mutually exclusive with mem_mb)

--- a/photon_mosaic_pipeline/workflow/config.yaml
+++ b/photon_mosaic_pipeline/workflow/config.yaml
@@ -173,20 +173,34 @@ suite2p_ops:
 # Settings for SLURM job scheduling system
 use_slurm: false
 slurm:
-  slurm_partition: "gpu"  # GPU partition for processing
-  mem_mb: 32000          # Memory allocation in MB
-  tasks: 1               # Number of tasks
-  nodes: 1               # Number of nodes to use
+  # One block per rule, named after the rule. Each rule uses ONLY its own
+  # block, so a CPU-only step never inherits the GPU request and never has to
+  # wait in the GPU queue for a resource it does not use.
+  #
+  # Keys shared between rules go in the `_common` anchor below and are pulled
+  # in with `<<: *common`. Keys starting with `_` are config scaffolding and
+  # are never passed to SLURM.
+  _common: &common
+    tasks: 1               # Number of tasks
+    nodes: 1               # Number of nodes to use
+    # runtime: 120         # Walltime limit in minutes
+    # slurm_account: "your_account_name"  # Replace with YOUR cluster account
+    # constraint: "feature"  # Node feature requirements
 
-  # GPU-specific resources (will be set at rule level, not via --default-resources)
-  # Uncomment and configure as needed:
-  # gpu: 1                 # Number of GPUs to request
-  # gres: "gpu:a100:1"     # Alternative: Generic Resource (GRES) specification
-  # cpus_per_gpu: 4        # CPUs allocated per GPU
-  # tasks_per_gpu: 0       # Tasks per GPU (set to 0 to disable --ntasks-per-gpu and avoid TRES conflicts)
+  preprocessing:
+    <<: *common
+    slurm_partition: "cpu"  # Preprocessing is CPU-only
+    mem_mb: 8000            # Memory allocation in MB
 
-  # Additional SLURM resources that can be specified:
-  # runtime: 120           # Walltime limit in minutes
-  # slurm_account: "account_name"  # SLURM account for resource tracking
-  # constraint: "feature"  # Node feature requirements
-  # mem_mb_per_cpu: 2000   # Memory per CPU (mutually exclusive with mem_mb)
+  suite2p:
+    <<: *common
+    slurm_partition: "gpu"  # GPU partition for processing
+    mem_mb: 32000           # Memory allocation in MB
+
+    # GPU resources. `gpu` and `gres` are mutually exclusive - pick one.
+    # Uncomment and configure as needed:
+    # gpu: 1                 # Number of GPUs to request
+    # gres: "gpu:a100:1"     # Alternative: Generic Resource (GRES) specification
+    # cpus_per_gpu: 4        # CPUs allocated per GPU
+    # tasks_per_gpu: 0       # Tasks per GPU (set to 0 to disable --ntasks-per-gpu and avoid TRES conflicts)
+    # mem_mb_per_cpu: 2000   # Memory per CPU (mutually exclusive with mem_mb)

--- a/photon_mosaic_pipeline/workflow/preprocessing.smk
+++ b/photon_mosaic_pipeline/workflow/preprocessing.smk
@@ -14,14 +14,14 @@ Output: Preprocessed TIFF files organized by subject/session
 
 from pathlib import Path
 from photon_mosaic_pipeline.rules.preprocessing import run_preprocessing
-from photon_mosaic_pipeline.snakemake_utils import cross_platform_path
+from photon_mosaic_pipeline.snakemake_utils import (
+    cross_platform_path,
+    slurm_resources,
+)
 from photon_mosaic_pipeline.paths_selection import _RAWDATA, _DERIVATIVES
 import re
 import logging
 import os
-
-# Configure SLURM resources if enabled
-slurm_config = config.get("slurm", {}) if config.get("use_slurm") else {}
 
 
 def _get_raw_tiff_for_wildcards(wildcards):
@@ -76,7 +76,7 @@ rule preprocessing:
         subject_name="|".join(_subject_names),
         session_name="|".join(_session_names),
     resources:
-        **(slurm_config if config.get("use_slurm") else {}),
+        **slurm_resources(config, "preprocessing"),
     run:
         from photon_mosaic_pipeline.rules.preprocessing import run_preprocessing
 

--- a/photon_mosaic_pipeline/workflow/suite2p.smk
+++ b/photon_mosaic_pipeline/workflow/suite2p.smk
@@ -12,7 +12,10 @@ Output: Suite2p analysis results (F.npy, data.bin) in suite2p/plane0/ directory
 """
 
 import re
-from photon_mosaic_pipeline.snakemake_utils import cross_platform_path
+from photon_mosaic_pipeline.snakemake_utils import (
+    cross_platform_path,
+    slurm_resources,
+)
 from photon_mosaic_pipeline.paths_selection import _DERIVATIVES
 
 
@@ -74,7 +77,7 @@ rule suite2p:
         subject_name="|".join(_subject_names),
         session_name="|".join(_session_names),
     resources:
-        **(slurm_config if config.get("use_slurm") else {}),
+        **slurm_resources(config, "suite2p"),
     run:
         from photon_mosaic_pipeline.rules.suite2p_run import run_suite2p
         from pathlib import Path

--- a/tests/test_unit/test_cli.py
+++ b/tests/test_unit/test_cli.py
@@ -165,3 +165,37 @@ def test_log_paths_not_injected_when_slurm_disabled(tmp_path):
     inject_slurm_log_paths(config)
 
     assert "slurm_extra" not in config["slurm"]["suite2p"]
+
+
+def test_log_paths_reach_rules_in_a_mixed_config(tmp_path):
+    """A config may be migrated one rule at a time; none may lose its logs.
+
+    With flat keys AND a per-rule block, `suite2p` uses its block while
+    `preprocessing` still falls back to the flat keys. Injecting only into the
+    sub-blocks left preprocessing with resources but no --output/--error, so
+    its sbatch logs went to the working directory -- silently, and exactly the
+    class of "no error log" report in #108.
+
+    Also pins that the fallback is a fallback, not inheritance: the blocked
+    rule must NOT pick up the flat keys.
+    """
+    config = {
+        "use_slurm": True,
+        "project_path": str(tmp_path),
+        "slurm": {
+            "slurm_partition": "cpu",
+            "mem_mb": 8000,
+            "suite2p": {"slurm_partition": "gpu", "gres": "gpu:a4500:1"},
+        },
+    }
+
+    inject_slurm_log_paths(config)
+
+    unblocked = slurm_resources(config, "preprocessing")
+    blocked = slurm_resources(config, "suite2p")
+
+    assert "--output=" in unblocked["slurm_extra"]
+    assert "--output=" in blocked["slurm_extra"]
+    # The blocked rule uses its own block only -- no inheritance.
+    assert "mem_mb" not in blocked
+    assert blocked["slurm_partition"] == "gpu"

--- a/tests/test_unit/test_cli.py
+++ b/tests/test_unit/test_cli.py
@@ -5,7 +5,9 @@ Unit tests for the CLI module.
 from photon_mosaic_pipeline.cli import (
     build_snakemake_command,
     configure_slurm_execution,
+    inject_slurm_log_paths,
 )
+from photon_mosaic_pipeline.snakemake_utils import slurm_resources
 
 
 def test_build_snakemake_command_basic(cli_args, snake_test_env):
@@ -46,8 +48,8 @@ def test_build_snakemake_command_dry_run(cli_args, snake_test_env):
 # Regression guard for commit 713390e, where the SLURM logging directives were
 # silently replaced by `slurm_extra = "--nodelist=gpu-350-05"`. The tests below
 # encode the contract this function must keep: log flags present, logdir under
-# the project, slurm_extra built from the logdir (NOT a hardcoded nodelist),
-# and rule-level GPU resources excluded from --default-resources.
+# the project, and slurm_extra built from the logdir (NOT a hardcoded
+# nodelist) -- see inject_slurm_log_paths further down, which now owns that.
 # ---------------------------------------------------------------------------
 
 
@@ -82,53 +84,84 @@ def test_configure_slurm_enabled_adds_executor_and_logdir(tmp_path):
     assert expected_logdir.is_dir()
 
 
-def test_configure_slurm_extra_uses_logdir_not_nodelist(tmp_path):
-    """slurm_extra must point sbatch --output / --error at the logdir.
+def test_configure_slurm_emits_no_default_resources(tmp_path):
+    """--default-resources must not be passed at all.
 
-    Regression guard for 713390e: that commit replaced this assignment with
-    `slurm_extra = "--nodelist=gpu-350-05"`, dropping the logging directives
-    AND pinning every job to one node. Both regressions are caught here.
+    Every rule reads its own block from the config, so there is nothing for
+    the defaults to supply. Keeping them would be actively harmful: snakemake
+    fills defaults in for any resource a rule does NOT set, silently putting
+    back values a rule deliberately left out.
     """
+    config = {
+        "use_slurm": True,
+        "project_path": str(tmp_path),
+        "slurm": {
+            "preprocessing": {"slurm_partition": "cpu"},
+            "suite2p": {"slurm_partition": "gpu", "gres": "gpu:a4500:1"},
+        },
+    }
+
+    cmd = configure_slurm_execution(["snakemake"], config)
+
+    assert "--default-resources" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# inject_slurm_log_paths
+#
+# slurm_extra carries the sbatch --output/--error paths. Rules read their
+# resources from the WRITTEN config file, and there are no default resources
+# to fall back on, so the paths have to be in every rule's block before that
+# file is saved. If this silently missed a block, that rule's logs would land
+# wherever SLURM defaults to and #108-style "no error log" reports follow.
+# ---------------------------------------------------------------------------
+
+
+def test_log_paths_reach_every_rule_block(tmp_path):
+    """Each rule's block gets slurm_extra pointing at the log directory."""
+    config = {
+        "use_slurm": True,
+        "project_path": str(tmp_path),
+        "slurm": {
+            "_common": {"tasks": 1},
+            "preprocessing": {"slurm_partition": "cpu"},
+            "suite2p": {"slurm_partition": "gpu"},
+        },
+    }
+
+    inject_slurm_log_paths(config)
+
+    expected_logdir = (
+        tmp_path / "derivatives" / "photon-mosaic-pipeline" / "logs" / "slurm"
+    )
+    for rule_name in ("preprocessing", "suite2p"):
+        slurm_extra = slurm_resources(config, rule_name)["slurm_extra"]
+        assert f"--output={expected_logdir}/%j_%x.out" in slurm_extra
+        assert f"--error={expected_logdir}/%j_%x.err" in slurm_extra
+        assert "--nodelist" not in slurm_extra
+
+
+def test_log_paths_reach_a_flat_config(tmp_path):
+    """A flat slurm: block gets the log paths on the block itself."""
     config = {
         "use_slurm": True,
         "project_path": str(tmp_path),
         "slurm": {"slurm_partition": "gpu"},
     }
 
-    cmd = configure_slurm_execution(["snakemake"], config)
+    inject_slurm_log_paths(config)
 
-    resources = cmd[cmd.index("--default-resources") + 1]
-    expected_logdir = (
-        tmp_path / "derivatives" / "photon-mosaic-pipeline" / "logs" / "slurm"
-    )
-    assert f"--output={expected_logdir}/%j_%x.out" in resources
-    assert f"--error={expected_logdir}/%j_%x.err" in resources
-    assert "--nodelist" not in resources
+    assert "--output=" in slurm_resources(config, "suite2p")["slurm_extra"]
 
 
-def test_configure_slurm_excludes_rule_level_gpu_resources(tmp_path):
-    """gpu / gres / cpus_per_gpu live at rule level, not in defaults.
-
-    Passing them via --default-resources triggers SLURM TRES conflicts.
-    The function must strip them while keeping other slurm: keys.
-    """
+def test_log_paths_not_injected_when_slurm_disabled(tmp_path):
+    """With use_slurm false nothing is touched."""
     config = {
-        "use_slurm": True,
+        "use_slurm": False,
         "project_path": str(tmp_path),
-        "slurm": {
-            "slurm_partition": "gpu",
-            "mem_mb": 16000,
-            "gpu": 1,
-            "gres": "gpu:1",
-            "cpus_per_gpu": 4,
-        },
+        "slurm": {"suite2p": {"slurm_partition": "gpu"}},
     }
 
-    cmd = configure_slurm_execution(["snakemake"], config)
+    inject_slurm_log_paths(config)
 
-    resources = cmd[cmd.index("--default-resources") + 1]
-    assert "slurm_partition='gpu'" in resources
-    assert "mem_mb=16000" in resources
-    assert "gpu=" not in resources
-    assert "gres=" not in resources
-    assert "cpus_per_gpu=" not in resources
+    assert "slurm_extra" not in config["slurm"]["suite2p"]

--- a/tests/test_unit/test_snakemake_utils.py
+++ b/tests/test_unit/test_snakemake_utils.py
@@ -15,125 +15,133 @@ from photon_mosaic_pipeline.snakemake_utils import slurm_resources
 #
 # The `slurm:` block holds one sub-block per rule, named after the rule. A rule
 # reads ONLY its own block: nothing is inherited, so nothing ever has to be
-# removed. These tests encode that, plus the backwards-compatible reading of a
-# flat `slurm:` block (which applied to every rule before per-rule blocks
+# removed. The cases below encode that, plus the backwards-compatible reading
+# of a flat `slurm:` block (which applied to every rule before per-rule blocks
 # existed) and the two kinds of key that must never reach SLURM -- nulls and
 # the `_`-prefixed anchors used for YAML reuse.
 # ---------------------------------------------------------------------------
 
+PER_RULE = {
+    "use_slurm": True,
+    "slurm": {
+        "preprocessing": {"slurm_partition": "cpu", "mem_mb": 8000},
+        "suite2p": {"slurm_partition": "gpu", "gres": "gpu:a4500:1"},
+    },
+}
 
-def test_rule_gets_its_own_block():
-    """Each rule resolves to its own sub-block, nothing else."""
-    config = {
-        "use_slurm": True,
-        "slurm": {
-            "preprocessing": {"slurm_partition": "cpu", "mem_mb": 8000},
-            "suite2p": {"slurm_partition": "gpu", "gres": "gpu:a4500:1"},
-        },
-    }
+FLAT = {
+    "use_slurm": True,
+    "slurm": {"slurm_partition": "gpu", "mem_mb": 32000},
+}
 
-    assert slurm_resources(config, "preprocessing") == {
-        "slurm_partition": "cpu",
-        "mem_mb": 8000,
-    }
-    assert slurm_resources(config, "suite2p") == {
+MIXED = {
+    "use_slurm": True,
+    "slurm": {
         "slurm_partition": "gpu",
-        "gres": "gpu:a4500:1",
-    }
+        "suite2p": {"gres": "gpu:a4500:1"},
+    },
+}
+
+ANCHORED = {
+    "use_slurm": True,
+    "slurm": {
+        "_common": {"tasks": 1},
+        "suite2p": {"_note": "ignored", "tasks": 1, "mem_mb": 32000},
+    },
+}
 
 
-def test_a_rule_never_inherits_another_rules_keys():
-    """The point of the design: no inheritance, so no removal needed.
-
-    `gres` belongs to suite2p only. Under the previous shape every rule got
-    the whole `slurm:` block, so preprocessing requested a GPU it never used
-    and queued behind busy GPUs for nothing.
-    """
-    config = {
-        "use_slurm": True,
-        "slurm": {
-            "preprocessing": {"slurm_partition": "cpu"},
-            "suite2p": {"slurm_partition": "gpu", "gres": "gpu:a4500:1"},
-        },
-    }
-
-    assert "gres" not in slurm_resources(config, "preprocessing")
-
-
-def test_flat_block_applies_to_every_rule():
-    """Backwards compatibility: a config with no per-rule sub-blocks.
-
-    Existing user configs are flat. They must keep behaving exactly as before,
-    with the whole block going to every rule.
-    """
-    config = {
-        "use_slurm": True,
-        "slurm": {"slurm_partition": "gpu", "mem_mb": 32000},
-    }
-
-    expected = {"slurm_partition": "gpu", "mem_mb": 32000}
-    assert slurm_resources(config, "preprocessing") == expected
-    assert slurm_resources(config, "suite2p") == expected
-
-
-def test_flat_fallback_ignores_unrelated_sub_blocks():
-    """A rule with no block of its own falls back to the flat keys only.
-
-    The other rules' sub-blocks are not resources and must not leak in --
-    Snakemake resources must be scalars, and a dict there is an error.
-    """
-    config = {
-        "use_slurm": True,
-        "slurm": {
-            "slurm_partition": "gpu",
-            "suite2p": {"gres": "gpu:a4500:1"},
-        },
-    }
-
-    resources = slurm_resources(config, "preprocessing")
-
-    assert resources == {"slurm_partition": "gpu"}
-    assert not any(isinstance(v, dict) for v in resources.values())
-
-
-def test_anchor_scaffolding_is_not_a_resource():
-    """`_`-prefixed keys hold YAML anchors and must never reach SLURM."""
-    config = {
-        "use_slurm": True,
-        "slurm": {
-            "_common": {"tasks": 1},
-            "suite2p": {"_note": "ignored", "tasks": 1, "mem_mb": 32000},
-        },
-    }
-
-    assert slurm_resources(config, "suite2p") == {"tasks": 1, "mem_mb": 32000}
-    assert slurm_resources(config, "preprocessing") == {}
-
-
-def test_null_values_are_dropped():
-    """A null is the absence of a resource, not a resource valued None."""
-    config = {
-        "use_slurm": True,
-        "slurm": {"suite2p": {"slurm_partition": "gpu", "gres": None}},
-    }
-
-    assert slurm_resources(config, "suite2p") == {"slurm_partition": "gpu"}
-
-
-def test_no_resources_when_slurm_is_disabled():
-    """With use_slurm false the rules must request nothing at all."""
-    config = {
-        "use_slurm": False,
-        "slurm": {"suite2p": {"slurm_partition": "gpu"}},
-    }
-
-    assert slurm_resources(config, "suite2p") == {}
-
-
-def test_missing_slurm_block_is_tolerated():
-    """No slurm: block at all resolves to no resources, not an error."""
-    assert slurm_resources({"use_slurm": True}, "suite2p") == {}
-    assert slurm_resources({"use_slurm": True, "slurm": None}, "suite2p") == {}
+@pytest.mark.parametrize(
+    "config, rule_name, expected",
+    [
+        # Each rule resolves to its own sub-block, and nothing else. `gres`
+        # belongs to suite2p only: under the previous shape every rule got the
+        # whole `slurm:` block, so preprocessing requested a GPU it never used
+        # and queued behind busy GPUs for nothing.
+        pytest.param(
+            PER_RULE,
+            "preprocessing",
+            {"slurm_partition": "cpu", "mem_mb": 8000},
+            id="own-block",
+        ),
+        pytest.param(
+            PER_RULE,
+            "suite2p",
+            {"slurm_partition": "gpu", "gres": "gpu:a4500:1"},
+            id="no-inheritance",
+        ),
+        # Backwards compatibility: existing user configs are flat and must
+        # keep behaving exactly as before, the whole block going to every rule.
+        pytest.param(
+            FLAT,
+            "preprocessing",
+            {"slurm_partition": "gpu", "mem_mb": 32000},
+            id="flat-applies-to-preprocessing",
+        ),
+        pytest.param(
+            FLAT,
+            "suite2p",
+            {"slurm_partition": "gpu", "mem_mb": 32000},
+            id="flat-applies-to-suite2p",
+        ),
+        # A rule with no block of its own falls back to the flat keys ONLY.
+        # Another rule's sub-block is not a resource, and Snakemake resources
+        # must be scalars -- a dict there is an error.
+        pytest.param(
+            MIXED,
+            "preprocessing",
+            {"slurm_partition": "gpu"},
+            id="flat-fallback-ignores-sibling-blocks",
+        ),
+        # ... and the blocked rule does not pick the flat keys up as well.
+        pytest.param(
+            MIXED,
+            "suite2p",
+            {"gres": "gpu:a4500:1"},
+            id="fallback-is-not-inheritance",
+        ),
+        # `_`-prefixed keys hold YAML anchors: config scaffolding, never a
+        # resource, at either level.
+        pytest.param(
+            ANCHORED,
+            "suite2p",
+            {"tasks": 1, "mem_mb": 32000},
+            id="anchor-scaffolding-is-not-a-resource",
+        ),
+        pytest.param(ANCHORED, "preprocessing", {}, id="anchor-is-not-a-rule"),
+        # A null is the absence of a resource, not a resource valued None.
+        pytest.param(
+            {
+                "use_slurm": True,
+                "slurm": {"suite2p": {"slurm_partition": "gpu", "gres": None}},
+            },
+            "suite2p",
+            {"slurm_partition": "gpu"},
+            id="nulls-dropped",
+        ),
+        # With use_slurm false the rules must request nothing at all, and a
+        # missing block resolves to no resources rather than raising.
+        pytest.param(
+            {
+                "use_slurm": False,
+                "slurm": {"suite2p": {"slurm_partition": "gpu"}},
+            },
+            "suite2p",
+            {},
+            id="slurm-disabled",
+        ),
+        pytest.param({"use_slurm": True}, "suite2p", {}, id="no-slurm-block"),
+        pytest.param(
+            {"use_slurm": True, "slurm": None},
+            "suite2p",
+            {},
+            id="null-slurm-block",
+        ),
+    ],
+)
+def test_slurm_resources(config, rule_name, expected):
+    """A rule resolves to its own block, minus scaffolding and nulls."""
+    assert slurm_resources(config, rule_name) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -186,25 +194,3 @@ def test_shipped_config_has_a_block_for_every_rule():
     for rule_name in rule_names:
         assert rule_name in config["slurm"], f"no slurm block for {rule_name}"
         assert slurm_resources(config, rule_name), f"empty block: {rule_name}"
-
-
-def test_shipped_config_ships_no_site_specific_values():
-    """The example config must not carry one site's account or partition.
-
-    `slurm_account` is cluster-specific; shipping a real one (e.g. an SWC
-    account) makes the example wrong everywhere else, so it stays commented
-    out with an obvious placeholder.
-    """
-    workflow_dir = get_snakefile_path().parent
-    raw = (workflow_dir / "config.yaml").read_text()
-    config = yaml.safe_load(raw)
-
-    def accounts(block):
-        if isinstance(block, dict):
-            for key, value in block.items():
-                if key == "slurm_account":
-                    yield value
-                yield from accounts(value)
-
-    assert not list(accounts(config["slurm"])), "slurm_account must be unset"
-    assert "your_account_name" in raw

--- a/tests/test_unit/test_snakemake_utils.py
+++ b/tests/test_unit/test_snakemake_utils.py
@@ -166,7 +166,8 @@ def test_smk_file_resolves_resources_for_its_own_rule(smk_filename, rule_name):
 def test_shipped_config_has_a_block_for_every_rule():
     """Every rule in the workflow needs a block in the shipped config.
 
-    A rule with no block silently gets no resources -- so when a new rule is
+    A rule with no block silently requests nothing but its log paths, and is
+    submitted with whatever the cluster defaults to -- so when a new rule is
     added (dff, neuropil, cascade ...) this fails until its block exists.
     """
     workflow_dir = get_snakefile_path().parent

--- a/tests/test_unit/test_snakemake_utils.py
+++ b/tests/test_unit/test_snakemake_utils.py
@@ -1,0 +1,209 @@
+"""
+Unit tests for the Snakemake utility functions.
+"""
+
+import re
+
+import pytest
+import yaml
+
+from photon_mosaic_pipeline import get_snakefile_path
+from photon_mosaic_pipeline.snakemake_utils import slurm_resources
+
+# ---------------------------------------------------------------------------
+# slurm_resources
+#
+# The `slurm:` block holds one sub-block per rule, named after the rule. A rule
+# reads ONLY its own block: nothing is inherited, so nothing ever has to be
+# removed. These tests encode that, plus the backwards-compatible reading of a
+# flat `slurm:` block (which applied to every rule before per-rule blocks
+# existed) and the two kinds of key that must never reach SLURM -- nulls and
+# the `_`-prefixed anchors used for YAML reuse.
+# ---------------------------------------------------------------------------
+
+
+def test_rule_gets_its_own_block():
+    """Each rule resolves to its own sub-block, nothing else."""
+    config = {
+        "use_slurm": True,
+        "slurm": {
+            "preprocessing": {"slurm_partition": "cpu", "mem_mb": 8000},
+            "suite2p": {"slurm_partition": "gpu", "gres": "gpu:a4500:1"},
+        },
+    }
+
+    assert slurm_resources(config, "preprocessing") == {
+        "slurm_partition": "cpu",
+        "mem_mb": 8000,
+    }
+    assert slurm_resources(config, "suite2p") == {
+        "slurm_partition": "gpu",
+        "gres": "gpu:a4500:1",
+    }
+
+
+def test_a_rule_never_inherits_another_rules_keys():
+    """The point of the design: no inheritance, so no removal needed.
+
+    `gres` belongs to suite2p only. Under the previous shape every rule got
+    the whole `slurm:` block, so preprocessing requested a GPU it never used
+    and queued behind busy GPUs for nothing.
+    """
+    config = {
+        "use_slurm": True,
+        "slurm": {
+            "preprocessing": {"slurm_partition": "cpu"},
+            "suite2p": {"slurm_partition": "gpu", "gres": "gpu:a4500:1"},
+        },
+    }
+
+    assert "gres" not in slurm_resources(config, "preprocessing")
+
+
+def test_flat_block_applies_to_every_rule():
+    """Backwards compatibility: a config with no per-rule sub-blocks.
+
+    Existing user configs are flat. They must keep behaving exactly as before,
+    with the whole block going to every rule.
+    """
+    config = {
+        "use_slurm": True,
+        "slurm": {"slurm_partition": "gpu", "mem_mb": 32000},
+    }
+
+    expected = {"slurm_partition": "gpu", "mem_mb": 32000}
+    assert slurm_resources(config, "preprocessing") == expected
+    assert slurm_resources(config, "suite2p") == expected
+
+
+def test_flat_fallback_ignores_unrelated_sub_blocks():
+    """A rule with no block of its own falls back to the flat keys only.
+
+    The other rules' sub-blocks are not resources and must not leak in --
+    Snakemake resources must be scalars, and a dict there is an error.
+    """
+    config = {
+        "use_slurm": True,
+        "slurm": {
+            "slurm_partition": "gpu",
+            "suite2p": {"gres": "gpu:a4500:1"},
+        },
+    }
+
+    resources = slurm_resources(config, "preprocessing")
+
+    assert resources == {"slurm_partition": "gpu"}
+    assert not any(isinstance(v, dict) for v in resources.values())
+
+
+def test_anchor_scaffolding_is_not_a_resource():
+    """`_`-prefixed keys hold YAML anchors and must never reach SLURM."""
+    config = {
+        "use_slurm": True,
+        "slurm": {
+            "_common": {"tasks": 1},
+            "suite2p": {"_note": "ignored", "tasks": 1, "mem_mb": 32000},
+        },
+    }
+
+    assert slurm_resources(config, "suite2p") == {"tasks": 1, "mem_mb": 32000}
+    assert slurm_resources(config, "preprocessing") == {}
+
+
+def test_null_values_are_dropped():
+    """A null is the absence of a resource, not a resource valued None."""
+    config = {
+        "use_slurm": True,
+        "slurm": {"suite2p": {"slurm_partition": "gpu", "gres": None}},
+    }
+
+    assert slurm_resources(config, "suite2p") == {"slurm_partition": "gpu"}
+
+
+def test_no_resources_when_slurm_is_disabled():
+    """With use_slurm false the rules must request nothing at all."""
+    config = {
+        "use_slurm": False,
+        "slurm": {"suite2p": {"slurm_partition": "gpu"}},
+    }
+
+    assert slurm_resources(config, "suite2p") == {}
+
+
+def test_missing_slurm_block_is_tolerated():
+    """No slurm: block at all resolves to no resources, not an error."""
+    assert slurm_resources({"use_slurm": True}, "suite2p") == {}
+    assert slurm_resources({"use_slurm": True, "slurm": None}, "suite2p") == {}
+
+
+# ---------------------------------------------------------------------------
+# The shipped config and the workflow must agree
+#
+# slurm_resources is keyed by rule name, so the feature hinges on each .smk
+# passing its OWN name and on the shipped config using those same names. A typo
+# on either side is silent -- the rule just gets nothing -- so pin both against
+# each other rather than trusting them separately.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "smk_filename, rule_name",
+    [("preprocessing.smk", "preprocessing"), ("suite2p.smk", "suite2p")],
+)
+def test_smk_file_resolves_resources_for_its_own_rule(smk_filename, rule_name):
+    """Each workflow file must declare and resolve the SAME rule name."""
+    source = (get_snakefile_path().parent / smk_filename).read_text()
+
+    declared = re.findall(r"^rule\s+(\w+)\s*:", source, flags=re.MULTILINE)
+    resolved = re.findall(
+        r"slurm_resources\(\s*config\s*,\s*[\"'](\w+)[\"']", source
+    )
+
+    assert declared == [rule_name], f"{smk_filename} declares {declared}"
+    assert resolved == [rule_name], f"{smk_filename} resolves {resolved}"
+
+
+def test_shipped_config_has_a_block_for_every_rule():
+    """Every rule in the workflow needs a block in the shipped config.
+
+    A rule with no block silently gets no resources -- so when a new rule is
+    added (dff, neuropil, cascade ...) this fails until its block exists.
+    """
+    workflow_dir = get_snakefile_path().parent
+    config = yaml.safe_load((workflow_dir / "config.yaml").read_text())
+    config["use_slurm"] = True
+
+    rule_names = [
+        rule
+        for smk in sorted(workflow_dir.glob("*.smk"))
+        for rule in re.findall(
+            r"^rule\s+(\w+)\s*:", smk.read_text(), flags=re.MULTILINE
+        )
+    ]
+
+    assert rule_names, "no rules found in the workflow"
+    for rule_name in rule_names:
+        assert rule_name in config["slurm"], f"no slurm block for {rule_name}"
+        assert slurm_resources(config, rule_name), f"empty block: {rule_name}"
+
+
+def test_shipped_config_ships_no_site_specific_values():
+    """The example config must not carry one site's account or partition.
+
+    `slurm_account` is cluster-specific; shipping a real one (e.g. an SWC
+    account) makes the example wrong everywhere else, so it stays commented
+    out with an obvious placeholder.
+    """
+    workflow_dir = get_snakefile_path().parent
+    raw = (workflow_dir / "config.yaml").read_text()
+    config = yaml.safe_load(raw)
+
+    def accounts(block):
+        if isinstance(block, dict):
+            for key, value in block.items():
+                if key == "slurm_account":
+                    yield value
+                yield from accounts(value)
+
+    assert not list(accounts(config["slurm"])), "slurm_account must be unset"
+    assert "your_account_name" in raw


### PR DESCRIPTION
Running the pipeline several times, it can happen that by requesting a lot of GPU resources SLURM de-prioritises our jobs. To minimise this I think it is worth having specific resources per rule.

This PR adds per rule specific SLURM configurations, so we stop requesting GPU nodes for the pre-processing step, and as for now only for suite2p. In this implementation we explicitly name the rule and the resources. The only downside is that every time we add a new rule we have to also edit this portion of the config.

Added relevant documentation section and tests.
`cly.py` has been refactored. 
Closes #82